### PR TITLE
Adding the country and postalCode to orderForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- orderForm integration from PLP to cart
+
+
 ## [0.1.2] - 2024-09-12
 
 ## [0.1.1] - 2024-09-12

--- a/react/client.ts
+++ b/react/client.ts
@@ -38,7 +38,7 @@ export const updateOrderForm = (
 ) =>
   fetch(`/api/checkout/pub/orderForm/${orderFormId}/attachments/shippingData`, {
     method: 'POST',
-    body: `{"selectedAddresses": [{ "postalCode": ${zipCode}, "country": ${country} ]}`,
+    body: `{"selectedAddresses": [{ "postalCode": ${zipCode}, "country": "${country}" }]}`,
     headers: {
       'Content-Type': 'application/json',
     },

--- a/react/client.ts
+++ b/react/client.ts
@@ -30,3 +30,16 @@ export const getPickups = (
   fetch(
     `/api/checkout/pub/pickup-points?an=${account}&countryCode=${countryCode}&postalCode=${zipCode}`
   ).then((res) => res.json())
+
+export const updateOrderForm = (
+  country: string,
+  zipCode: string,
+  orderFormId: string
+) =>
+  fetch(`/api/checkout/pub/orderForm/${orderFormId}/attachments/shippingData`, {
+    method: 'POST',
+    body: `{"selectedAddresses": [{ "postalCode": ${zipCode}, "country": ${country} ]}`,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  }).then((res) => res.json())

--- a/react/hooks/useShippingOptions.ts
+++ b/react/hooks/useShippingOptions.ts
@@ -4,9 +4,14 @@ import { useRuntime, useSSR } from 'vtex.render-runtime'
 import { useIntl } from 'react-intl'
 import { usePixel } from 'vtex.pixel-manager'
 
-import { getCountryCode, getZipCode } from '../utils/cookie'
+import { getCountryCode, getOrderFormId, getZipCode } from '../utils/cookie'
 import messages from '../messages'
-import { getAddress, getPickups, updateSession } from '../client'
+import {
+  getAddress,
+  getPickups,
+  updateOrderForm,
+  updateSession,
+} from '../client'
 
 declare let window: any
 
@@ -103,6 +108,12 @@ const useShippingOptions = () => {
     setCity(undefined)
 
     setIsLoading(true)
+
+    const orderFormId = getOrderFormId()
+
+    if (orderFormId) {
+      await updateOrderForm(inputZipCode, orderFormId, countryCode)
+    }
 
     const { geoCoordinates: coordinates } = await getAddress(
       countryCode,

--- a/react/hooks/useShippingOptions.ts
+++ b/react/hooks/useShippingOptions.ts
@@ -112,7 +112,7 @@ const useShippingOptions = () => {
     const orderFormId = getOrderFormId()
 
     if (orderFormId) {
-      await updateOrderForm(inputZipCode, orderFormId, countryCode)
+      await updateOrderForm(countryCode, inputZipCode, orderFormId)
     }
 
     const { geoCoordinates: coordinates } = await getAddress(

--- a/react/utils/cookie.ts
+++ b/react/utils/cookie.ts
@@ -50,3 +50,13 @@ export function getCountryCode() {
 
   return countryCode
 }
+
+export function getOrderFormId() {
+  const orderForm = localStorage.getItem('orderform')
+
+  if (!orderForm) {
+    return
+  }
+
+  return JSON.parse(orderForm || '{}').id
+}


### PR DESCRIPTION
#### What problem is this solving?

This problem aims to fix one issue that it's currently happening on PLP where on it the postalCode is one and checking on the orderForm the values are null, so to fix it the OrderForm API was added and and update on it was created.

#### How to test it?
Go to the:
[Workspace](https://rfonseca--vinotecamx.myvtex.com/)

And you can check using the following commands:
`localStorage.orderform`

It will show to you the current value from the orderform, then on the top right corner it an `ubicacíon` should be set, when the enter button is pressed run again the orderform command and check the `postalCode` and `country` values.

Then add a product on the minicart and check if on the cart it's everything working as intended. 

#### Screenshots or example usage:
(PLP)
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/9a7aa264-3c3c-4211-8d44-88f1d1cdbb3e">
<img width="1497" alt="image" src="https://github.com/user-attachments/assets/8c2cfada-03ac-4918-8a4e-0bcfbc414759">

(Cart Page)
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/375e66fe-875d-4918-b126-900e74277572">
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/56196f3b-cd54-42b0-8c25-bedc71bd72f1">


#### Describe alternatives you've considered, if any.

If this is a dangerous deploy to Checkout it should be considered to be added on the Minicart app.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdTJxenkzY2hzZGp0Y3E5eGxneXFjY3Y5dHl5ZGx2bWlpc2t6bHo4dSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xT5LMAvRY92qUXj7dC/giphy.gif)
