### PR TITLE
[SAX-329] Mobile drawer should be widthfull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust drawer width to mobile
+
 ## [0.1.2] - 2024-09-12
 
 ## [0.1.1] - 2024-09-12
@@ -14,11 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2024-09-12
 
 ### Fixed
+
 - English, Portuguese and Spanish translations.
 - Crowdin integration file.
 
 ### Added
+
 - Bulgharian, German, French, Italian, Japanese, Korean, Dutch, Romanian and Thai translations
 
 ### Added
+
 - Initial release.

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,8 @@
     "vtex.css-handles": "0.x",
     "vtex.render-runtime": "8.x",
     "vtex.store-drawer": "0.x",
-    "vtex.pixel-manager": "1.x"
+    "vtex.pixel-manager": "1.x",
+    "vtex.device-detector": "0.x"
   },
   "registries": ["smartcheckout"],
   "policies": [],

--- a/react/components/ShippingOptionDrawer.tsx
+++ b/react/components/ShippingOptionDrawer.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from 'react'
 import { Drawer, DrawerHeader, DrawerCloseButton } from 'vtex.store-drawer'
+import { useDevice } from 'vtex.device-detector'
 
 import '../styles.css'
 
@@ -18,12 +19,15 @@ const ShippingOptionDrawer = ({
   children,
   icon,
 }: PropsWithChildren<Props>) => {
+  const { isMobile } = useDevice()
+
   return (
     <Drawer
       customIcon={icon}
       className="dn"
       slideDirection="rightToLeft"
       customPixelEventId={customPixelEventId}
+      isFullWidth={isMobile}
       header={
         <DrawerHeader>
           <DrawerCloseButton />

--- a/react/typings/vtex.device-detector.d.ts
+++ b/react/typings/vtex.device-detector.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.device-detector' {
+  export const useDevice
+}


### PR DESCRIPTION
#### What problem is this solving?

Drawer component should have width full for mobile.
It was solved adding vtex.device-detector dependency and using it in ShippingOptionDrawer component.

#### How to test it?

[Workspace](https://luaradp--vinotecamx.myvtex.com/)

#### Screenshots or example usage:

**Before**

https://github.com/user-attachments/assets/20a94426-ecff-413b-8cb2-b2c1bfb4d94e



**After**

https://github.com/user-attachments/assets/7693eecf-d771-4151-bab2-fb0e5443ad3f


#### Related to / Depends on

https://vtex-dev.atlassian.net/browse/SAX-329
