### PR TITLE
change moment where pickupPoint is cookied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Selected pickup doesn't work on first load
+
 ## [0.4.0] - 2024-10-04
 
 ### Fixed

--- a/react/hooks/useShippingOptions.ts
+++ b/react/hooks/useShippingOptions.ts
@@ -139,8 +139,9 @@ const useShippingOptions = () => {
 
     await updateSession(inputZipCode, coordinates)
 
+    await fetchPickups(countryCode, inputZipCode, coordinates)
+
     if (!reload) {
-      await fetchPickups(countryCode, inputZipCode, coordinates)
       setIsLoading(false)
     }
 


### PR DESCRIPTION
#### What problem is this solving?

When the user adds the zipcode and the page is reloaded, the pickupPoint is not being send to the backend. This is happening because the  the API that return the pickuppoints was not being callend before the reload, only after it

