### PR TITLE
fix: add zIndex for the drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Drawer opens behind the sidebar
+
 ## [0.4.0] - 2024-10-04
 
 ### Fixed

--- a/react/components/ShippingOptionDrawer.tsx
+++ b/react/components/ShippingOptionDrawer.tsx
@@ -24,6 +24,7 @@ const ShippingOptionDrawer = ({
   return (
     <Drawer
       customIcon={icon}
+      zIndex={99999}
       className="dn"
       slideDirection="rightToLeft"
       customPixelEventId={customPixelEventId}


### PR DESCRIPTION
#### What problem is this solving?

The filter sidebar on mobile opens above the shipping drawer

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://dpfacets2--fulfillmentqa.myvtex.com/)

#### Screenshots or example usage:
https://github.com/user-attachments/assets/42d352e3-75f8-4159-8ca8-ebc13325d569
<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
