### PR TITLE
feat: add input in popover to define postal code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Open a popover to the delivery button.
+- Popover to open the location drawer;
+- Popover with input to add postal code.
 
 ## [0.4.2] - 2024-11-06
-
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -16,11 +16,10 @@
     "vtex.render-runtime": "8.x",
     "vtex.store-drawer": "0.x",
     "vtex.pixel-manager": "1.x",
-    "vtex.device-detector": "0.x"
+    "vtex.device-detector": "0.x",
+    "vtex.address-form": "4.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Преглед на магазините във вашия регион",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Избиране на магазин",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Въвеждане на пощенския ви код",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Въведеният пощенски код не е в района на нашето покритие",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Въведеният пощенски код не е в района на нашето покритие",
   "store/shipping-option-zipcode.currentLocationButton": "Използване на настоящото местоположение",
   "store/shipping-option-zipcode.storeHoursButton": "Преглед на работното време на магазина",
   "store/shipping-option-zipcode.viewMoreButton": "Преглед на повече",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Преглед на магазините във вашия регион",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Избиране на магазин",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Въвеждане на пощенския ви код",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Въведеният пощенски код не е в района на нашето покритие",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Въведеният пощенски код не е в района на нашето покритие",
   "store/shipping-option-zipcode.currentLocationButton": "Използване на настоящото местоположение",
   "store/shipping-option-zipcode.storeHoursButton": "Преглед на работното време на магазина",
   "store/shipping-option-zipcode.viewMoreButton": "Преглед на повече",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Mostrar les botigues a la vostra regió",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Tria una botiga",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Introduïu el vostre codi postal",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "El codi postal introduït no forma part de la nostra zona de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error": "El codi postal introduït no forma part de la nostra zona de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Fes servir la ubicació actual",
   "store/shipping-option-zipcode.storeHoursButton": "Mostra l'horari de la botiga",
   "store/shipping-option-zipcode.viewMoreButton": "Mostra'n més",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Mostrar les botigues a la vostra regió",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Tria una botiga",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Introduïu el vostre codi postal",
-  "store/shipping-option-zipcode.postalCodeInput.error": "El codi postal introduït no forma part de la nostra zona de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "El codi postal introduït no forma part de la nostra zona de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Fes servir la ubicació actual",
   "store/shipping-option-zipcode.storeHoursButton": "Mostra l'horari de la botiga",
   "store/shipping-option-zipcode.viewMoreButton": "Mostra'n més",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Prohlédněte si obchody ve svém regionu",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Vyberte si obchod",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Zadejte své poštovní směrovací číslo",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Zadané poštovní směrovací číslo se nenachází v naší oblasti pokrytí",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Zadané poštovní směrovací číslo se nenachází v naší oblasti pokrytí",
   "store/shipping-option-zipcode.currentLocationButton": "Použít aktuální polohu",
   "store/shipping-option-zipcode.storeHoursButton": "Zobrazit otevírací dobu obchodu",
   "store/shipping-option-zipcode.viewMoreButton": "Zobrazit více",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Prohlédněte si obchody ve svém regionu",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Vyberte si obchod",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Zadejte své poštovní směrovací číslo",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Zadané poštovní směrovací číslo se nenachází v naší oblasti pokrytí",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Zadané poštovní směrovací číslo se nenachází v naší oblasti pokrytí",
   "store/shipping-option-zipcode.currentLocationButton": "Použít aktuální polohu",
   "store/shipping-option-zipcode.storeHoursButton": "Zobrazit otevírací dobu obchodu",
   "store/shipping-option-zipcode.viewMoreButton": "Zobrazit více",

--- a/messages/da.json
+++ b/messages/da.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Vis butikker i din region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Vælg en butik",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Indtast dit postnummer",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Det indtastede postnummer er ikke indenfor dit dækningsområde",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Det indtastede postnummer er ikke indenfor dit dækningsområde",
   "store/shipping-option-zipcode.currentLocationButton": "Brug nuværende lokation",
   "store/shipping-option-zipcode.storeHoursButton": "Vis butikkens åbningstider",
   "store/shipping-option-zipcode.viewMoreButton": "Vis mere",

--- a/messages/da.json
+++ b/messages/da.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Vis butikker i din region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Vælg en butik",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Indtast dit postnummer",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Det indtastede postnummer er ikke indenfor dit dækningsområde",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Det indtastede postnummer er ikke indenfor dit dækningsområde",
   "store/shipping-option-zipcode.currentLocationButton": "Brug nuværende lokation",
   "store/shipping-option-zipcode.storeHoursButton": "Vis butikkens åbningstider",
   "store/shipping-option-zipcode.viewMoreButton": "Vis mere",

--- a/messages/de.json
+++ b/messages/de.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Shops in Ihrer Region anzeigen",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Shop auswählen",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Geben Sie Ihre Postleitzahl ein",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Die eingegebene Postleitzahl ist nicht in unserem Abdeckungsbereich",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Die eingegebene Postleitzahl ist nicht in unserem Abdeckungsbereich",
   "store/shipping-option-zipcode.currentLocationButton": "Aktuellen Standort verwenden",
   "store/shipping-option-zipcode.storeHoursButton": "Ladenöffnungszeiten anzeigen",
   "store/shipping-option-zipcode.viewMoreButton": "Mehr ansehen",

--- a/messages/de.json
+++ b/messages/de.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Shops in Ihrer Region anzeigen",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Shop auswählen",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Geben Sie Ihre Postleitzahl ein",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Die eingegebene Postleitzahl ist nicht in unserem Abdeckungsbereich",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Die eingegebene Postleitzahl ist nicht in unserem Abdeckungsbereich",
   "store/shipping-option-zipcode.currentLocationButton": "Aktuellen Standort verwenden",
   "store/shipping-option-zipcode.storeHoursButton": "Ladenöffnungszeiten anzeigen",
   "store/shipping-option-zipcode.viewMoreButton": "Mehr ansehen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Προβολή καταστημάτων στην περιοχή σας",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Επιλέξτε ένα κατάστημα",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Εισαγάγετε τον ταχυδρομικό σας κώδικα",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Ο ταχυδρομικός κώδικας που καταχωρήσατε δεν βρίσκεται εντός της περιοχής κάλυψής μας",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Ο ταχυδρομικός κώδικας που καταχωρήσατε δεν βρίσκεται εντός της περιοχής κάλυψής μας",
   "store/shipping-option-zipcode.currentLocationButton": "Χρήση τρέχουσας τοποθεσίας",
   "store/shipping-option-zipcode.storeHoursButton": "Προβολή ωρών λειτουργίας καταστήματος",
   "store/shipping-option-zipcode.viewMoreButton": "Προβολή περισσοτέρων",

--- a/messages/el.json
+++ b/messages/el.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Προβολή καταστημάτων στην περιοχή σας",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Επιλέξτε ένα κατάστημα",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Εισαγάγετε τον ταχυδρομικό σας κώδικα",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Ο ταχυδρομικός κώδικας που καταχωρήσατε δεν βρίσκεται εντός της περιοχής κάλυψής μας",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Ο ταχυδρομικός κώδικας που καταχωρήσατε δεν βρίσκεται εντός της περιοχής κάλυψής μας",
   "store/shipping-option-zipcode.currentLocationButton": "Χρήση τρέχουσας τοποθεσίας",
   "store/shipping-option-zipcode.storeHoursButton": "Προβολή ωρών λειτουργίας καταστήματος",
   "store/shipping-option-zipcode.viewMoreButton": "Προβολή περισσοτέρων",

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,5 +22,6 @@
   "store/shipping-option-zipcode.popoverButton.label": "Select a location",
   "store/shipping-option-zipcode.popover.description": "Offers and delivery options vary based on region.",
   "store/shipping-option-zipcode.deliveryPopover.submitButton.label": "Continue",
-  "store/shipping-option-zipcode.deliveryPopover.postalCodeInput.placeholder": "Postal Code"
+  "store/shipping-option-zipcode.deliveryPopover.postalCodeInput.placeholder": "Postal Code",
+  "store/shipping-option-zipcode.popover.postalCodeLink": "I don't know my postal code"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "View stores in your region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Choose a store",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Enter your postal code",
-  "store/shipping-option-zipcode.postalCodeInput.error": "The entered postal code is not within our coverage area",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "The entered postal code is not within our coverage area",
   "store/shipping-option-zipcode.currentLocationButton": "Use Current Location",
   "store/shipping-option-zipcode.storeHoursButton": "View Store Hours",
   "store/shipping-option-zipcode.viewMoreButton": "View More",

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "View stores in your region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Choose a store",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Enter your postal code",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "The entered postal code is not within our coverage area",
+  "store/shipping-option-zipcode.postalCodeInput.error": "The entered postal code is not within our coverage area",
   "store/shipping-option-zipcode.currentLocationButton": "Use Current Location",
   "store/shipping-option-zipcode.storeHoursButton": "View Store Hours",
   "store/shipping-option-zipcode.viewMoreButton": "View More",
@@ -20,5 +20,7 @@
   "store/shipping-option-zipcode.shippinFilter.pickpu": "Pickup",
   "store/shipping-option-zipcode.updateButton.label": "Update",
   "store/shipping-option-zipcode.popoverButton.label": "Select a location",
-  "store/shipping-option-zipcode.popover.description": "Shipping options and speed may vary based on delivery address and store"
+  "store/shipping-option-zipcode.popover.description": "Delivery options and delivery speeds may vary per address and store.",
+  "store/shipping-option-zipcode.deliveryPopover.submitButton.label": "Continue",
+  "store/shipping-option-zipcode.deliveryPopover.postalCodeInput.placeholder": "Postal Code"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,7 +20,7 @@
   "store/shipping-option-zipcode.shippinFilter.pickpu": "Pickup",
   "store/shipping-option-zipcode.updateButton.label": "Update",
   "store/shipping-option-zipcode.popoverButton.label": "Select a location",
-  "store/shipping-option-zipcode.popover.description": "Delivery options and delivery speeds may vary per address and store.",
+  "store/shipping-option-zipcode.popover.description": "Offers and delivery options vary based on region.",
   "store/shipping-option-zipcode.deliveryPopover.submitButton.label": "Continue",
   "store/shipping-option-zipcode.deliveryPopover.postalCodeInput.placeholder": "Postal Code"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "View stores in your region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Choose a store",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Enter your postal code",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "The entered postal code is not within our coverage area",
+  "store/shipping-option-zipcode.postalCodeInput.error": "The entered postal code is not within our coverage area",
   "store/shipping-option-zipcode.currentLocationButton": "Use Current Location",
   "store/shipping-option-zipcode.storeHoursButton": "View Store Hours",
   "store/shipping-option-zipcode.viewMoreButton": "View More",

--- a/messages/es.json
+++ b/messages/es.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Consulta las tiendas en tu región",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Selecciona una tienda",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Ingresa tu código postal",
-  "store/shipping-option-zipcode.postalCodeInput.error": "El código postal ingresado no está incluido en nuestra área de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "El código postal ingresado no está incluido en nuestra área de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usar la ubicación actual",
   "store/shipping-option-zipcode.storeHoursButton": "Horario de la tienda",
   "store/shipping-option-zipcode.viewMoreButton": "Ver más",

--- a/messages/es.json
+++ b/messages/es.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Consulta las tiendas en tu región",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Selecciona una tienda",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Ingresa tu código postal",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "El código postal ingresado no está incluido en nuestra área de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error": "El código postal ingresado no está incluido en nuestra área de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usar la ubicación actual",
   "store/shipping-option-zipcode.storeHoursButton": "Horario de la tienda",
   "store/shipping-option-zipcode.viewMoreButton": "Ver más",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Näytä alueesi myymälät",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Valitse myymälä",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Anna postinumerosi",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Annettu postinumero ei kuulu kattavuusalueellemme",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Annettu postinumero ei kuulu kattavuusalueellemme",
   "store/shipping-option-zipcode.currentLocationButton": "Käytä nykyistä sijaintia",
   "store/shipping-option-zipcode.storeHoursButton": "Näytä myymälän aukioloajat",
   "store/shipping-option-zipcode.viewMoreButton": "Näytä lisää",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Näytä alueesi myymälät",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Valitse myymälä",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Anna postinumerosi",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Annettu postinumero ei kuulu kattavuusalueellemme",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Annettu postinumero ei kuulu kattavuusalueellemme",
   "store/shipping-option-zipcode.currentLocationButton": "Käytä nykyistä sijaintia",
   "store/shipping-option-zipcode.storeHoursButton": "Näytä myymälän aukioloajat",
   "store/shipping-option-zipcode.viewMoreButton": "Näytä lisää",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Voir les magasins de votre région",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Choisissez un magasin",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Entrez votre code postal",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Le code postal saisi ne se trouve pas dans notre zone de couverture",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Le code postal saisi ne se trouve pas dans notre zone de couverture",
   "store/shipping-option-zipcode.currentLocationButton": "Utiliser la localisation actuelle",
   "store/shipping-option-zipcode.storeHoursButton": "Voir les heures d’ouverture du magasin",
   "store/shipping-option-zipcode.viewMoreButton": "Afficher plus",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Voir les magasins de votre région",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Choisissez un magasin",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Entrez votre code postal",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Le code postal saisi ne se trouve pas dans notre zone de couverture",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Le code postal saisi ne se trouve pas dans notre zone de couverture",
   "store/shipping-option-zipcode.currentLocationButton": "Utiliser la localisation actuelle",
   "store/shipping-option-zipcode.storeHoursButton": "Voir les heures d’ouverture du magasin",
   "store/shipping-option-zipcode.viewMoreButton": "Afficher plus",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Üzletek megtekintése a régiójában",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Válasszon egy üzletet",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Adja meg az irányítószámát",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "A megadott irányítószám nem tartozik a lefedettségi területünkhöz",
+  "store/shipping-option-zipcode.postalCodeInput.error": "A megadott irányítószám nem tartozik a lefedettségi területünkhöz",
   "store/shipping-option-zipcode.currentLocationButton": "Aktuális tartózkodási hely használata",
   "store/shipping-option-zipcode.storeHoursButton": "Nyitvatartási idő megtekintése",
   "store/shipping-option-zipcode.viewMoreButton": "Több megtekintése",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Üzletek megtekintése a régiójában",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Válasszon egy üzletet",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Adja meg az irányítószámát",
-  "store/shipping-option-zipcode.postalCodeInput.error": "A megadott irányítószám nem tartozik a lefedettségi területünkhöz",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "A megadott irányítószám nem tartozik a lefedettségi területünkhöz",
   "store/shipping-option-zipcode.currentLocationButton": "Aktuális tartózkodási hely használata",
   "store/shipping-option-zipcode.storeHoursButton": "Nyitvatartási idő megtekintése",
   "store/shipping-option-zipcode.viewMoreButton": "Több megtekintése",

--- a/messages/id.json
+++ b/messages/id.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Lihat toko di wilayah Anda",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Pilih toko",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Masukkan kode pos Anda",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Kode pos yang dimasukkan tidak masuk area jangkauan kami",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Kode pos yang dimasukkan tidak masuk area jangkauan kami",
   "store/shipping-option-zipcode.currentLocationButton": "Gunakan Lokasi Saat Ini",
   "store/shipping-option-zipcode.storeHoursButton": "Lihat Jam Toko",
   "store/shipping-option-zipcode.viewMoreButton": "Lihat Selengkapnya",

--- a/messages/id.json
+++ b/messages/id.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Lihat toko di wilayah Anda",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Pilih toko",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Masukkan kode pos Anda",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Kode pos yang dimasukkan tidak masuk area jangkauan kami",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Kode pos yang dimasukkan tidak masuk area jangkauan kami",
   "store/shipping-option-zipcode.currentLocationButton": "Gunakan Lokasi Saat Ini",
   "store/shipping-option-zipcode.storeHoursButton": "Lihat Jam Toko",
   "store/shipping-option-zipcode.viewMoreButton": "Lihat Selengkapnya",

--- a/messages/it.json
+++ b/messages/it.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Vedi i negozi nella tua regione",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Scegli un negozio",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Inserisci il tuo codice di avviamento postale",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Il codice di avviamento postale inserito non rientra nella nostra zona di copertura",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Il codice di avviamento postale inserito non rientra nella nostra zona di copertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usa posizione attuale",
   "store/shipping-option-zipcode.storeHoursButton": "Orari del negozio",
   "store/shipping-option-zipcode.viewMoreButton": "Mostra di più",

--- a/messages/it.json
+++ b/messages/it.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Vedi i negozi nella tua regione",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Scegli un negozio",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Inserisci il tuo codice di avviamento postale",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Il codice di avviamento postale inserito non rientra nella nostra zona di copertura",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Il codice di avviamento postale inserito non rientra nella nostra zona di copertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usa posizione attuale",
   "store/shipping-option-zipcode.storeHoursButton": "Orari del negozio",
   "store/shipping-option-zipcode.viewMoreButton": "Mostra di più",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "お住まいの地域の店舗を見る",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "店舗を選択",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "郵便番号を入力してください",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "入力された郵便番号は、当社のサービス提供地域外です。",
+  "store/shipping-option-zipcode.postalCodeInput.error": "入力された郵便番号は、当社のサービス提供地域外です。",
   "store/shipping-option-zipcode.currentLocationButton": "現在地を使用",
   "store/shipping-option-zipcode.storeHoursButton": "営業時間を見る",
   "store/shipping-option-zipcode.viewMoreButton": "もっと見る",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "お住まいの地域の店舗を見る",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "店舗を選択",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "郵便番号を入力してください",
-  "store/shipping-option-zipcode.postalCodeInput.error": "入力された郵便番号は、当社のサービス提供地域外です。",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "入力された郵便番号は、当社のサービス提供地域外です。",
   "store/shipping-option-zipcode.currentLocationButton": "現在地を使用",
   "store/shipping-option-zipcode.storeHoursButton": "営業時間を見る",
   "store/shipping-option-zipcode.viewMoreButton": "もっと見る",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "해당 지역의 스토어 보기",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "스토어 선택",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "우편번호 입력",
-  "store/shipping-option-zipcode.postalCodeInput.error": "입력한 우편번호가 당사의 서비스 지역 내에 있지 않습니다",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "입력한 우편번호가 당사의 서비스 지역 내에 있지 않습니다",
   "store/shipping-option-zipcode.currentLocationButton": "현재 위치 사용",
   "store/shipping-option-zipcode.storeHoursButton": "매장 시간 보기",
   "store/shipping-option-zipcode.viewMoreButton": "더 보기",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "해당 지역의 스토어 보기",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "스토어 선택",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "우편번호 입력",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "입력한 우편번호가 당사의 서비스 지역 내에 있지 않습니다",
+  "store/shipping-option-zipcode.postalCodeInput.error": "입력한 우편번호가 당사의 서비스 지역 내에 있지 않습니다",
   "store/shipping-option-zipcode.currentLocationButton": "현재 위치 사용",
   "store/shipping-option-zipcode.storeHoursButton": "매장 시간 보기",
   "store/shipping-option-zipcode.viewMoreButton": "더 보기",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Bekijk winkels in uw regio",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Kies een winkel",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Voer uw postcode in",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "De ingevoerde postcode valt niet binnen ons gebied",
+  "store/shipping-option-zipcode.postalCodeInput.error": "De ingevoerde postcode valt niet binnen ons gebied",
   "store/shipping-option-zipcode.currentLocationButton": "Gebruik huidige locatie",
   "store/shipping-option-zipcode.storeHoursButton": "Winkeluren bekijken",
   "store/shipping-option-zipcode.viewMoreButton": "Meer weergeven",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Bekijk winkels in uw regio",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Kies een winkel",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Voer uw postcode in",
-  "store/shipping-option-zipcode.postalCodeInput.error": "De ingevoerde postcode valt niet binnen ons gebied",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "De ingevoerde postcode valt niet binnen ons gebied",
   "store/shipping-option-zipcode.currentLocationButton": "Gebruik huidige locatie",
   "store/shipping-option-zipcode.storeHoursButton": "Winkeluren bekijken",
   "store/shipping-option-zipcode.viewMoreButton": "Meer weergeven",

--- a/messages/no.json
+++ b/messages/no.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Se butikker i din region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Velg en butikk",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Skriv inn postkode",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Postnummeret du skrev inn er ikke innenfor vårt dekningsområde",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Postnummeret du skrev inn er ikke innenfor vårt dekningsområde",
   "store/shipping-option-zipcode.currentLocationButton": "Bruk gjeldende posisjon",
   "store/shipping-option-zipcode.storeHoursButton": "Vis butikktimer",
   "store/shipping-option-zipcode.viewMoreButton": "Vis mere",

--- a/messages/no.json
+++ b/messages/no.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Se butikker i din region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Velg en butikk",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Skriv inn postkode",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Postnummeret du skrev inn er ikke innenfor vårt dekningsområde",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Postnummeret du skrev inn er ikke innenfor vårt dekningsområde",
   "store/shipping-option-zipcode.currentLocationButton": "Bruk gjeldende posisjon",
   "store/shipping-option-zipcode.storeHoursButton": "Vis butikktimer",
   "store/shipping-option-zipcode.viewMoreButton": "Vis mere",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Wyświetl sklepy w swoim regionie",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Wybierz sklep",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Wprowadź swój kod pocztowy",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Wprowadzony kod pocztowy nie znajduje się w naszym zasięgu",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Wprowadzony kod pocztowy nie znajduje się w naszym zasięgu",
   "store/shipping-option-zipcode.currentLocationButton": "Użyj bieżącej lokalizacji",
   "store/shipping-option-zipcode.storeHoursButton": "Zobacz godziny otwarcia sklepu",
   "store/shipping-option-zipcode.viewMoreButton": "Zobacz więcej",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Wyświetl sklepy w swoim regionie",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Wybierz sklep",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Wprowadź swój kod pocztowy",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Wprowadzony kod pocztowy nie znajduje się w naszym zasięgu",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Wprowadzony kod pocztowy nie znajduje się w naszym zasięgu",
   "store/shipping-option-zipcode.currentLocationButton": "Użyj bieżącej lokalizacji",
   "store/shipping-option-zipcode.storeHoursButton": "Zobacz godziny otwarcia sklepu",
   "store/shipping-option-zipcode.viewMoreButton": "Zobacz więcej",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Veja as lojas em sua região",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Escolha uma loja",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Insira seu código postal",
-  "store/shipping-option-zipcode.postalCodeInput.error": "O código postal inserido não está dentro da nossa área de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "O código postal inserido não está dentro da nossa área de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usar localização atual",
   "store/shipping-option-zipcode.storeHoursButton": "Ver horários da loja",
   "store/shipping-option-zipcode.viewMoreButton": "Ver mais",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -20,6 +20,5 @@
   "store/shipping-option-zipcode.shippinFilter.pickpu": "Retirada",
   "store/shipping-option-zipcode.updateButton.label": "Atualizar",
   "store/shipping-option-zipcode.popoverButton.label": "Selecione um local",
-  "store/shipping-option-zipcode.popover.description": "As opções e a velocidade de entrega podem variar conforme o endereço e a loja",
-  "store/shipping-option-zipcode.deliveryPopover.submitButton.label": "Continue"
+  "store/shipping-option-zipcode.popover.description": "As opções e a velocidade de entrega podem variar conforme o endereço e a loja"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Veja as lojas em sua região",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Escolha uma loja",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Insira seu código postal",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "O código postal inserido não está dentro da nossa área de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error": "O código postal inserido não está dentro da nossa área de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usar localização atual",
   "store/shipping-option-zipcode.storeHoursButton": "Ver horários da loja",
   "store/shipping-option-zipcode.viewMoreButton": "Ver mais",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -20,5 +20,5 @@
   "store/shipping-option-zipcode.shippinFilter.pickpu": "Retirada",
   "store/shipping-option-zipcode.updateButton.label": "Atualizar",
   "store/shipping-option-zipcode.popoverButton.label": "Selecione um local",
-  "store/shipping-option-zipcode.popover.description": "As opções e a velocidade de entrega podem variar conforme o endereço e a loja"
+  "store/shipping-option-zipcode.popover.description": "As ofertas e opções de entrega variam de acordo com a região."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Veja as lojas em sua região",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Escolha uma loja",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Insira seu código postal",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "O código postal inserido não está dentro da nossa área de cobertura",
+  "store/shipping-option-zipcode.postalCodeInput.error": "O código postal inserido não está dentro da nossa área de cobertura",
   "store/shipping-option-zipcode.currentLocationButton": "Usar localização atual",
   "store/shipping-option-zipcode.storeHoursButton": "Ver horários da loja",
   "store/shipping-option-zipcode.viewMoreButton": "Ver mais",
@@ -20,5 +20,6 @@
   "store/shipping-option-zipcode.shippinFilter.pickpu": "Retirada",
   "store/shipping-option-zipcode.updateButton.label": "Atualizar",
   "store/shipping-option-zipcode.popoverButton.label": "Selecione um local",
-  "store/shipping-option-zipcode.popover.description": "As opções e a velocidade de entrega podem variar conforme o endereço e a loja"
+  "store/shipping-option-zipcode.popover.description": "As opções e a velocidade de entrega podem variar conforme o endereço e a loja",
+  "store/shipping-option-zipcode.deliveryPopover.submitButton.label": "Continue"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Vezi magazinele din regiunea ta",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Alege un magazin",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Introdu codul poștal",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Codul poștal introdus nu se află în zona noastră de acoperire",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Codul poștal introdus nu se află în zona noastră de acoperire",
   "store/shipping-option-zipcode.currentLocationButton": "Folosește locația actuală",
   "store/shipping-option-zipcode.storeHoursButton": "Vezi programul magazinului",
   "store/shipping-option-zipcode.viewMoreButton": "Vezi mai mult",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Vezi magazinele din regiunea ta",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Alege un magazin",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Introdu codul poștal",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Codul poștal introdus nu se află în zona noastră de acoperire",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Codul poștal introdus nu se află în zona noastră de acoperire",
   "store/shipping-option-zipcode.currentLocationButton": "Folosește locația actuală",
   "store/shipping-option-zipcode.storeHoursButton": "Vezi programul magazinului",
   "store/shipping-option-zipcode.viewMoreButton": "Vezi mai mult",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Показать магазины в вашем регионе",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Выберите магазин",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Введите почтовый индекс",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Введенный почтовый индекс находится вне нашей зоны обслуживания",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Введенный почтовый индекс находится вне нашей зоны обслуживания",
   "store/shipping-option-zipcode.currentLocationButton": "Использовать текущее местоположение",
   "store/shipping-option-zipcode.storeHoursButton": "Показать график работы магазина",
   "store/shipping-option-zipcode.viewMoreButton": "Показать больше",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Показать магазины в вашем регионе",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Выберите магазин",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Введите почтовый индекс",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Введенный почтовый индекс находится вне нашей зоны обслуживания",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Введенный почтовый индекс находится вне нашей зоны обслуживания",
   "store/shipping-option-zipcode.currentLocationButton": "Использовать текущее местоположение",
   "store/shipping-option-zipcode.storeHoursButton": "Показать график работы магазина",
   "store/shipping-option-zipcode.viewMoreButton": "Показать больше",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Zobraziť obchody vo vašom regióne",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Vyberte obchod",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Zadajte svoje poštové smerovacie číslo",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Zadané poštové smerovacie číslo nie je v našej oblasti pokrytia",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Zadané poštové smerovacie číslo nie je v našej oblasti pokrytia",
   "store/shipping-option-zipcode.currentLocationButton": "Použiť aktuálnu polohu",
   "store/shipping-option-zipcode.storeHoursButton": "Zobraziť otváracie hodiny obchodu",
   "store/shipping-option-zipcode.viewMoreButton": "Zobraziť viac",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Zobraziť obchody vo vašom regióne",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Vyberte obchod",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Zadajte svoje poštové smerovacie číslo",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Zadané poštové smerovacie číslo nie je v našej oblasti pokrytia",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Zadané poštové smerovacie číslo nie je v našej oblasti pokrytia",
   "store/shipping-option-zipcode.currentLocationButton": "Použiť aktuálnu polohu",
   "store/shipping-option-zipcode.storeHoursButton": "Zobraziť otváracie hodiny obchodu",
   "store/shipping-option-zipcode.viewMoreButton": "Zobraziť viac",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Oglejte si trgovine v svoji regiji",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Izberi trgovino",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Vnesite svojo poštno številko",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Vnesena poštna številka ni na našem območju pokrivanja",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Vnesena poštna številka ni na našem območju pokrivanja",
   "store/shipping-option-zipcode.currentLocationButton": "Uporabi trenutno lokacijo",
   "store/shipping-option-zipcode.storeHoursButton": "Oglejte si ure trgovine",
   "store/shipping-option-zipcode.viewMoreButton": "Poglej več",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Oglejte si trgovine v svoji regiji",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Izberi trgovino",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Vnesite svojo poštno številko",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Vnesena poštna številka ni na našem območju pokrivanja",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Vnesena poštna številka ni na našem območju pokrivanja",
   "store/shipping-option-zipcode.currentLocationButton": "Uporabi trenutno lokacijo",
   "store/shipping-option-zipcode.storeHoursButton": "Oglejte si ure trgovine",
   "store/shipping-option-zipcode.viewMoreButton": "Poglej več",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Visa butiker i din region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Välj en butik",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Ange ditt postnummer",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Det angivna postnumret är inte inom vårt täckningsområde",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Det angivna postnumret är inte inom vårt täckningsområde",
   "store/shipping-option-zipcode.currentLocationButton": "Använd aktuell plats",
   "store/shipping-option-zipcode.storeHoursButton": "Visa butikstimmar",
   "store/shipping-option-zipcode.viewMoreButton": "Visa mer",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Visa butiker i din region",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Välj en butik",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Ange ditt postnummer",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Det angivna postnumret är inte inom vårt täckningsområde",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Det angivna postnumret är inte inom vårt täckningsområde",
   "store/shipping-option-zipcode.currentLocationButton": "Använd aktuell plats",
   "store/shipping-option-zipcode.storeHoursButton": "Visa butikstimmar",
   "store/shipping-option-zipcode.viewMoreButton": "Visa mer",

--- a/messages/th.json
+++ b/messages/th.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "ดูร้านค้าในภูมิภาคที่คุณอยู่",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "เลือกร้านค้า",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "ใส่รหัสไปรษณีย์ของคุณ",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "รหัสไปรษณีย์ที่ให้ไม่อยู่ในพื้นที่ดูแลของเรา",
+  "store/shipping-option-zipcode.postalCodeInput.error": "รหัสไปรษณีย์ที่ให้ไม่อยู่ในพื้นที่ดูแลของเรา",
   "store/shipping-option-zipcode.currentLocationButton": "ใช้ที่ตั้งปัจจุบัน",
   "store/shipping-option-zipcode.storeHoursButton": "ดูเวลาทำการของร้านค้า",
   "store/shipping-option-zipcode.viewMoreButton": "ดูเพิ่มเติม",

--- a/messages/th.json
+++ b/messages/th.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "ดูร้านค้าในภูมิภาคที่คุณอยู่",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "เลือกร้านค้า",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "ใส่รหัสไปรษณีย์ของคุณ",
-  "store/shipping-option-zipcode.postalCodeInput.error": "รหัสไปรษณีย์ที่ให้ไม่อยู่ในพื้นที่ดูแลของเรา",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "รหัสไปรษณีย์ที่ให้ไม่อยู่ในพื้นที่ดูแลของเรา",
   "store/shipping-option-zipcode.currentLocationButton": "ใช้ที่ตั้งปัจจุบัน",
   "store/shipping-option-zipcode.storeHoursButton": "ดูเวลาทำการของร้านค้า",
   "store/shipping-option-zipcode.viewMoreButton": "ดูเพิ่มเติม",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Переглянути магазини у вашому регіоні",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Виберіть магазин",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Введіть поштовий індекс",
-  "store/shipping-option-zipcode.postalCodeInput.error": "Введений поштовий індекс — поза нашою зоною обслуговування",
+  "store/shipping-option-zipcode.postalCodeInput.error.": "Введений поштовий індекс — поза нашою зоною обслуговування",
   "store/shipping-option-zipcode.currentLocationButton": "Використати поточне розташування",
   "store/shipping-option-zipcode.storeHoursButton": "Переглянути години роботи магазину",
   "store/shipping-option-zipcode.viewMoreButton": "Переглянути більше",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -7,7 +7,7 @@
   "store/shipping-option-zipcode.pickupDrawer.title.empty": "Переглянути магазини у вашому регіоні",
   "store/shipping-option-zipcode.pickupDrawer.title.filled": "Виберіть магазин",
   "store/shipping-option-zipcode.postalCodeInput.placeholder": "Введіть поштовий індекс",
-  "store/shipping-option-zipcode.postalCodeInput.error.": "Введений поштовий індекс — поза нашою зоною обслуговування",
+  "store/shipping-option-zipcode.postalCodeInput.error": "Введений поштовий індекс — поза нашою зоною обслуговування",
   "store/shipping-option-zipcode.currentLocationButton": "Використати поточне розташування",
   "store/shipping-option-zipcode.storeHoursButton": "Переглянути години роботи магазину",
   "store/shipping-option-zipcode.viewMoreButton": "Переглянути більше",

--- a/react/components/DeliveryDrawer.tsx
+++ b/react/components/DeliveryDrawer.tsx
@@ -17,7 +17,7 @@ interface Props {
   zipCode?: string
   selectedZipCode?: string
   compact: boolean
-  overlayMode?: OverlayMode
+  overlayType?: OverlayType
 }
 
 const DeliveryDrawer = ({
@@ -29,7 +29,7 @@ const DeliveryDrawer = ({
   selectedZipCode,
   zipCode,
   compact,
-  overlayMode,
+  overlayType,
 }: Props) => {
   const intl = useIntl()
   const { push } = usePixel()
@@ -54,7 +54,7 @@ const DeliveryDrawer = ({
           onChange={onChange}
           onSubmit={onSubmit}
           inputErrorMessage={inputErrorMessage}
-          overlayMode={overlayMode}
+          overlayType={overlayType}
         />
       }
       title={intl.formatMessage(messages.storeDeliverDrawerTitle)}

--- a/react/components/DeliveryDrawer.tsx
+++ b/react/components/DeliveryDrawer.tsx
@@ -17,6 +17,7 @@ interface Props {
   zipCode?: string
   selectedZipCode?: string
   compact: boolean
+  overlayMode?: OverlayMode
 }
 
 const DeliveryDrawer = ({
@@ -28,6 +29,7 @@ const DeliveryDrawer = ({
   selectedZipCode,
   zipCode,
   compact,
+  overlayMode,
 }: Props) => {
   const intl = useIntl()
   const { push } = usePixel()
@@ -48,7 +50,11 @@ const DeliveryDrawer = ({
           placeholder={intl.formatMessage(messages.deliverToButtonPlaceholder)}
           label={intl.formatMessage(messages.deliverToButtonLabel)}
           compact={compact}
-          showPopover
+          zipCode={zipCode}
+          onChange={onChange}
+          onSubmit={onSubmit}
+          inputErrorMessage={inputErrorMessage}
+          overlayMode={overlayMode}
         />
       }
       title={intl.formatMessage(messages.storeDeliverDrawerTitle)}

--- a/react/components/DeliveryPopover.tsx
+++ b/react/components/DeliveryPopover.tsx
@@ -1,36 +1,78 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import React from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import { Button } from 'vtex.styleguide'
 import OutsideClickHandler from 'react-outside-click-handler'
+import { useIntl } from 'react-intl'
+
 import '../styles.css'
+import PostalCodeInput from './PostalCodeInput'
+import messages from '../messages'
 
 const CSS_HANDLES = [
   'deliveryPopover',
   'popoverPolygonContainer',
   'popoverPolygonSvg',
   'popoverPolygon',
+  'popoverInputContainer',
 ] as const
 
 interface Props {
   onClick: () => void
   handleOutSideClick: () => void
-  description: string
-  buttonLabel: string
+  variant?: 'popover-button' | 'popover-input'
+  onChange: (zipCode?: string) => void
+  onSubmit: () => void
+  isLoading?: boolean
+  inputErrorMessage?: string
+  zipCode?: string
 }
 
 const DeliveryPopover = ({
   onClick,
-  description,
-  buttonLabel,
   handleOutSideClick,
+  variant = 'popover-input',
+  onChange,
+  onSubmit,
+  isLoading,
+  inputErrorMessage,
+  zipCode,
 }: Props) => {
   const handles = useCssHandles(CSS_HANDLES)
+  const intl = useIntl()
 
   return (
     <OutsideClickHandler onOutsideClick={handleOutSideClick}>
-      <div className={`${handles.deliveryPopover}`}>
-        <p className="ma0">{description}</p>
-        <Button onClick={onClick}>{buttonLabel}</Button>
+      <div
+        className={`${handles.deliveryPopover}`}
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+      >
+        <p className="ma0">{intl.formatMessage(messages.popoverDescription)}</p>
+        {variant === 'popover-button' ? (
+          <Button onClick={onClick}>
+            {intl.formatMessage(messages.popoverButtonLabel)}
+          </Button>
+        ) : (
+          <div className={`${handles.popoverInputContainer} flex`}>
+            <PostalCodeInput
+              zipCode={zipCode}
+              onSubmit={onSubmit}
+              errorMessage={inputErrorMessage}
+              onChange={onChange}
+              showClearButton={false}
+              placeholder={intl.formatMessage(
+                messages.popoverPostalCodeInputPlaceHolder
+              )}
+              newZipCodeTyped
+            />
+            <Button isLoading={isLoading} onClick={onSubmit}>
+              {intl.formatMessage(messages.popoverSubmitButtonLabel)}
+            </Button>
+          </div>
+        )}
 
         <span className={`${handles.popoverPolygonContainer}`}>
           <svg

--- a/react/components/DeliveryPopover.tsx
+++ b/react/components/DeliveryPopover.tsx
@@ -5,10 +5,13 @@ import { useCssHandles } from 'vtex.css-handles'
 import { Button } from 'vtex.styleguide'
 import OutsideClickHandler from 'react-outside-click-handler'
 import { useIntl } from 'react-intl'
-
+import { AddressRules } from 'vtex.address-form'
 import '../styles.css'
+
 import PostalCodeInput from './PostalCodeInput'
 import messages from '../messages'
+import PostalCodeHelpLink from './PostalCodeHelpLink'
+import { getCountryCode } from '../utils/cookie'
 
 const CSS_HANDLES = [
   'deliveryPopover',
@@ -27,6 +30,7 @@ interface Props {
   isLoading?: boolean
   inputErrorMessage?: string
   zipCode?: string
+  rules?: any
 }
 
 const DeliveryPopover = ({
@@ -50,7 +54,12 @@ const DeliveryPopover = ({
           e.stopPropagation()
         }}
       >
-        <p className="ma0">{intl.formatMessage(messages.popoverDescription)}</p>
+        <AddressRules country={getCountryCode()} shouldUseIOFetching>
+          <p className="ma0">
+            {`${intl.formatMessage(messages.popoverDescription)} `}
+            <PostalCodeHelpLink />
+          </p>
+        </AddressRules>
         {variant === 'popover-button' ? (
           <Button onClick={onClick}>
             {intl.formatMessage(messages.popoverButtonLabel)}

--- a/react/components/DeliverySelection.tsx
+++ b/react/components/DeliverySelection.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
+import { useIntl } from 'react-intl'
 
 import PostalCodeInput from './PostalCodeInput'
 import SubmitButton from './SubmitButton'
+import messages from '../messages'
 
 interface Props {
   onSubmit: (zipCode?: string) => void
@@ -24,6 +26,7 @@ const DeliverySelection = ({
 }: Props) => {
   const newZipCodeTyped = zipCode !== selectedZipCode
   const shouldHideUpdateButton = (!zipCode || !newZipCodeTyped) && !isLoading
+  const intl = useIntl()
 
   return (
     <div className="flex flex-column justify-between">
@@ -33,6 +36,8 @@ const DeliverySelection = ({
         errorMessage={inputErrorMessage}
         onChange={onChange}
         addressLabel={addressLabel}
+        placeholder={intl.formatMessage(messages.postalCodeInputPlaceHolder)}
+        newZipCodeTyped={newZipCodeTyped}
       />
       <div className="fixed left-0 bottom-0 w-100 flex justify-center mb7">
         <SubmitButton

--- a/react/components/PickupSelection.tsx
+++ b/react/components/PickupSelection.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { useDrawer } from 'vtex.store-drawer/DrawerContext'
+import { useIntl } from 'react-intl'
 
 import PostalCodeInput from './PostalCodeInput'
 import SubmitButton from './SubmitButton'
 import PickupItem from './PickupItem'
+import messages from '../messages'
 
 interface Props {
   onSubmit: (zipCode?: string) => void
@@ -33,16 +35,21 @@ const PickupSelection = ({
   const newZipCodeTyped = zipCode !== selectedZipCode
   const shouldHideUpdateButton = (!zipCode || !newZipCodeTyped) && !isLoading
   const { close } = useDrawer()
+  const intl = useIntl()
 
   return (
     <div className="flex flex-column justify-between">
-      <PostalCodeInput
-        zipCode={zipCode}
-        onSubmit={onSubmit}
-        errorMessage={inputErrorMessage}
-        onChange={onChange}
-        addressLabel={addressLabel}
-      />
+      <div className="mb7">
+        <PostalCodeInput
+          zipCode={zipCode}
+          onSubmit={onSubmit}
+          errorMessage={inputErrorMessage}
+          onChange={onChange}
+          addressLabel={addressLabel}
+          placeholder={intl.formatMessage(messages.postalCodeInputPlaceHolder)}
+          newZipCodeTyped={newZipCodeTyped}
+        />
+      </div>
       <div className="m-100 flex flex-column justify-center">
         {pickups.map((currentPickup) => (
           <PickupItem

--- a/react/components/PostalCodeHelpLink.tsx
+++ b/react/components/PostalCodeHelpLink.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { useIntl } from 'react-intl'
+import { helpers } from 'vtex.address-form'
+import { Link } from 'vtex.styleguide'
+import { useCssHandles } from 'vtex.css-handles'
+
+import messages from '../messages'
+
+const POSTAL_CODE_FIELD = 'postalCode'
+
+const CSS_HANDLES = ['postalCodeHelpLink'] as const
+
+interface Props {
+  rules?: any
+}
+
+const PostalCodeHelpLink = ({ rules }: Props) => {
+  const intl = useIntl()
+  const handles = useCssHandles(CSS_HANDLES)
+
+  let postalCodeFinderURL
+
+  if (rules) {
+    const postalCodeField = rules.fields?.find(
+      (field: any) => field.name === POSTAL_CODE_FIELD
+    )
+
+    postalCodeFinderURL = postalCodeField?.forgottenURL
+  }
+
+  if (!postalCodeFinderURL) {
+    return null
+  }
+
+  return (
+    <Link
+      href={postalCodeFinderURL}
+      target="_blank"
+      className={`${handles.postalCodeHelpLink}`}
+    >
+      {intl.formatMessage(messages.popoverPostalCodeLink)}
+    </Link>
+  )
+}
+
+export default helpers.injectRules(PostalCodeHelpLink)

--- a/react/components/PostalCodeInput.tsx
+++ b/react/components/PostalCodeInput.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useState } from 'react'
-import { useIntl } from 'react-intl'
 import { Input, IconClear } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 
-import messages from '../messages'
 import '../styles.css'
 import PinIcon from './PinIcon'
 
-const CSS_HANDLES = ['postalCodeInputClearButton', 'zipCodeValue'] as const
+const CSS_HANDLES = [
+  'postalCodeInputClearButton',
+  'zipCodeValue',
+  'postalCodeInputContainer',
+] as const
 
 interface ZipCodeValueProps {
   zipCode: string
@@ -32,6 +34,9 @@ interface Props {
   addressLabel?: string
   zipCode?: string
   errorMessage?: string
+  showClearButton?: boolean
+  placeholder?: string
+  newZipCodeTyped?: boolean
 }
 
 const PostalCodeInput = ({
@@ -40,6 +45,9 @@ const PostalCodeInput = ({
   onSubmit,
   onChange,
   addressLabel,
+  showClearButton = true,
+  placeholder,
+  newZipCodeTyped,
 }: Props) => {
   const [isZipCodeSet, setIsZipCodeSet] = useState(!!zipCode)
 
@@ -49,14 +57,13 @@ const PostalCodeInput = ({
     }
   }, [errorMessage])
 
-  const intl = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
-    <div className="mb7">
+    <div className={handles.postalCodeInputContainer}>
       {isZipCodeSet ? (
         <ZipCodeValue
-          zipCode={addressLabel ?? ''}
+          zipCode={(newZipCodeTyped ? zipCode : addressLabel) ?? ''}
           onClick={() => setIsZipCodeSet(false)}
         />
       ) : (
@@ -76,16 +83,18 @@ const PostalCodeInput = ({
           }}
           value={zipCode}
           errorMessage={errorMessage}
-          placeholder={intl.formatMessage(messages.postalCodeInputPlaceHolder)}
+          placeholder={placeholder}
           suffix={
-            <button
-              className={handles.postalCodeInputClearButton}
-              onClick={() => {
-                onChange('')
-              }}
-            >
-              <IconClear />
-            </button>
+            showClearButton ? (
+              <button
+                className={handles.postalCodeInputClearButton}
+                onClick={() => {
+                  onChange('')
+                }}
+              >
+                <IconClear />
+              </button>
+            ) : null
           }
         />
       )}

--- a/react/components/ShippingOptionButton.tsx
+++ b/react/components/ShippingOptionButton.tsx
@@ -23,7 +23,7 @@ interface Props {
   onChange?: (zipCode?: string) => void
   onSubmit?: () => void
   inputErrorMessage?: string
-  overlayMode?: OverlayMode
+  overlayType?: OverlayType
 }
 
 const ShippingOptionButton = ({
@@ -37,7 +37,7 @@ const ShippingOptionButton = ({
   onChange,
   onSubmit,
   inputErrorMessage,
-  overlayMode,
+  overlayType,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const handles = useCssHandles(CSS_HANDLES)
@@ -52,7 +52,7 @@ const ShippingOptionButton = ({
   }
 
   const showPopover =
-    overlayMode === 'popover-button' || overlayMode === 'popover-input'
+    overlayType === 'popover-button' || overlayType === 'popover-input'
 
   const isFirstLoading = !zipCode && loading
 
@@ -88,7 +88,7 @@ const ShippingOptionButton = ({
           isLoading={loading}
           inputErrorMessage={inputErrorMessage}
           zipCode={zipCode}
-          variant={overlayMode}
+          variant={overlayType}
         />
       )}
     </div>

--- a/react/components/ShippingOptionButton.tsx
+++ b/react/components/ShippingOptionButton.tsx
@@ -83,8 +83,8 @@ const ShippingOptionButton = ({
         <DeliveryPopover
           onClick={handlePopoverClick}
           handleOutSideClick={handleOutSideClick}
-          onChange={onChange || (() => {})}
-          onSubmit={onSubmit || (() => {})}
+          onChange={onChange ?? (() => {})}
+          onSubmit={onSubmit ?? (() => {})}
           isLoading={loading}
           inputErrorMessage={inputErrorMessage}
           zipCode={zipCode}

--- a/react/components/ShippingOptionButton.tsx
+++ b/react/components/ShippingOptionButton.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react'
 import { useCssHandles } from 'vtex.css-handles'
 import { Spinner } from 'vtex.styleguide'
-import { useIntl } from 'react-intl'
 import '../styles.css'
 
 import DeliveryPopover from './DeliveryPopover'
-import messages from '../messages'
 
 const CSS_HANDLES = [
   'buttonWrapper',
@@ -21,7 +19,11 @@ interface Props {
   placeholder: string
   value?: string
   compact: boolean
-  showPopover?: boolean
+  zipCode?: string
+  onChange?: (zipCode?: string) => void
+  onSubmit?: () => void
+  inputErrorMessage?: string
+  overlayMode?: OverlayMode
 }
 
 const ShippingOptionButton = ({
@@ -31,9 +33,12 @@ const ShippingOptionButton = ({
   value,
   placeholder,
   compact,
-  showPopover = false,
+  zipCode,
+  onChange,
+  onSubmit,
+  inputErrorMessage,
+  overlayMode,
 }: Props) => {
-  const intl = useIntl()
   const [isPopoverOpen, setIsPopoverOpen] = useState(true)
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -46,7 +51,12 @@ const ShippingOptionButton = ({
     setIsPopoverOpen(false)
   }
 
-  const openPopover = !loading && !value && showPopover && isPopoverOpen
+  const showPopover =
+    overlayMode === 'popover-button' || overlayMode === 'popover-input'
+
+  const isFirstLoading = !zipCode && loading
+
+  const openPopover = !isFirstLoading && !value && showPopover && isPopoverOpen
 
   return (
     <div className={`${handles.shippingButtonContainer} flex items-center`}>
@@ -71,10 +81,14 @@ const ShippingOptionButton = ({
       </button>
       {openPopover && (
         <DeliveryPopover
-          buttonLabel={intl.formatMessage(messages.popoverButtonLabel)}
-          description={intl.formatMessage(messages.popoverDescription)}
           onClick={handlePopoverClick}
           handleOutSideClick={handleOutSideClick}
+          onChange={onChange || (() => {})}
+          onSubmit={onSubmit || (() => {})}
+          isLoading={loading}
+          inputErrorMessage={inputErrorMessage}
+          zipCode={zipCode}
+          variant={overlayMode}
         />
       )}
     </div>

--- a/react/hooks/useShippingOptions.ts
+++ b/react/hooks/useShippingOptions.ts
@@ -113,7 +113,6 @@ const useShippingOptions = () => {
       return
     }
 
-    setSelectedZipCode(inputZipCode)
     setPickups([])
     setCity(undefined)
 
@@ -136,6 +135,8 @@ const useShippingOptions = () => {
 
       return
     }
+
+    setSelectedZipCode(inputZipCode)
 
     await updateSession(inputZipCode, coordinates)
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -10,13 +10,13 @@ import { getCookie } from './utils/cookie'
 interface Props {
   hideStoreSelection?: boolean
   compactMode?: boolean
-  overlayMode?: OverlayMode
+  overlayType?: OverlayType
 }
 
 function ShippingOptionZipCode({
   hideStoreSelection = false,
   compactMode = false,
-  overlayMode,
+  overlayType = 'popover-input',
 }: Props) {
   const { production } = useRuntime()
   const [shouldRender, setShouldRender] = useState<boolean>(!production)
@@ -63,7 +63,7 @@ function ShippingOptionZipCode({
         selectedZipCode={selectedZipCode}
         zipCode={zipCode}
         compact={compactMode}
-        overlayMode={overlayMode}
+        overlayType={overlayType}
       />
       {!hideStoreSelection && (
         <PikcupDrawer

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -10,11 +10,13 @@ import { getCookie } from './utils/cookie'
 interface Props {
   hideStoreSelection?: boolean
   compactMode?: boolean
+  overlayMode?: OverlayMode
 }
 
 function ShippingOptionZipCode({
   hideStoreSelection = false,
   compactMode = false,
+  overlayMode,
 }: Props) {
   const { production } = useRuntime()
   const [shouldRender, setShouldRender] = useState<boolean>(!production)
@@ -61,6 +63,7 @@ function ShippingOptionZipCode({
         selectedZipCode={selectedZipCode}
         zipCode={zipCode}
         compact={compactMode}
+        overlayMode={overlayMode}
       />
       {!hideStoreSelection && (
         <PikcupDrawer

--- a/react/messages.ts
+++ b/react/messages.ts
@@ -58,6 +58,10 @@ const messages = defineMessages({
       'store/shipping-option-zipcode.deliveryPopover.postalCodeInput.placeholder',
     defaultMessaage: '',
   },
+  popoverPostalCodeLink: {
+    id: 'store/shipping-option-zipcode.popover.postalCodeLink',
+    defaultMessaage: '',
+  },
 })
 
 export default messages

--- a/react/messages.ts
+++ b/react/messages.ts
@@ -45,8 +45,17 @@ const messages = defineMessages({
     id: 'store/shipping-option-zipcode.popoverButton.label',
     defaultMessaage: '',
   },
+  popoverSubmitButtonLabel: {
+    id: 'store/shipping-option-zipcode.deliveryPopover.submitButton.label',
+    defaultMessaage: '',
+  },
   popoverDescription: {
     id: 'store/shipping-option-zipcode.popover.description',
+    defaultMessaage: '',
+  },
+  popoverPostalCodeInputPlaceHolder: {
+    id:
+      'store/shipping-option-zipcode.deliveryPopover.postalCodeInput.placeholder',
     defaultMessaage: '',
   },
 })

--- a/react/styles.css
+++ b/react/styles.css
@@ -68,7 +68,7 @@
   background-color: #fff;
   box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.12);
   padding: 20px;
-  width: 320px;
+  width: 380px;
   cursor: auto;
   -webkit-animation: fadein 2s; /* Safari, Chrome and Opera > 12.1 */
   -moz-animation: fadein 2s; /* Firefox < 16 */
@@ -93,6 +93,15 @@
 
 .popoverPolygon {
   fill: #fff;
+}
+
+.popoverInputContainer {
+  gap: 16px;
+  align-items: start;
+}
+
+.postalCodeInputContainer {
+  width: 100%;
 }
 
 @keyframes fadein {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -14,7 +14,7 @@ declare interface Pickup {
   }
 }
 
-declare type OverlayMode = 'popover-button' | 'popover-input'
+declare type OverlayType = 'popover-button' | 'popover-input'
 
 declare global {
   interface Window {

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -14,6 +14,8 @@ declare interface Pickup {
   }
 }
 
+declare type OverlayMode = 'popover-button' | 'popover-input'
+
 declare global {
   interface Window {
     addressLabel?: stirng

--- a/react/typings/vtex.address-form.d.ts
+++ b/react/typings/vtex.address-form.d.ts
@@ -1,0 +1,4 @@
+declare module 'vtex.address-form' {
+  export const AddressRules
+  export const helpers
+}

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -4,4 +4,5 @@ declare module 'vtex.styleguide' {
   export const Input
   export const Spinner
   export const Button
+  export const Link
 }


### PR DESCRIPTION
#### What problem is this solving?

This PR add a popover with input to encourage the user to enter a location.

#### How to test it?

Starts the page without postal code defined.

[Workspace](https://arthurdp--biggy.myvtex.com/?__bindingAddress=biggy.myvtex.com/)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/c8bd019f-9de5-45aa-a6ce-4e702465470b


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
