### PR TITLE
add shipping_info cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- sometimes zip code is not updated due to a problem in `__RUNTIME__.segmentToken`
+
 ## [0.5.0] - 2024-12-18
+
 ### Added
 
 - Popover to open the location drawer;

--- a/react/client.ts
+++ b/react/client.ts
@@ -1,3 +1,6 @@
+import { SHIPPING_INFO_COOKIE } from './constants'
+import { setCookie } from './utils/cookie'
+
 export const getAddress = (
   countryCode: string,
   zipCode: string,
@@ -11,16 +14,23 @@ export const updateSession = (
   zipCode: string,
   geoCoordinates: number[],
   pickup?: Pickup
-) =>
-  fetch('/api/sessions', {
+) => {
+  const facetsValue = `zip-code=${zipCode};coordinates=${geoCoordinates.join(
+    ','
+  )}${pickup ? `;pickupPoint=${pickup.pickupPoint.id}` : ''}`
+
+  // __RUNTIME__.segmentToken is not reliable for the facets. It might not be updated. For this reason we must try to get the info from our custom cookie first
+  // Replacing ";" by ":" because ";" is not allowed in cookies
+  setCookie(SHIPPING_INFO_COOKIE, facetsValue.replace(';', ':'))
+
+  return fetch('/api/sessions', {
     method: 'POST',
-    body: `{"public":{"facets":{"value":"zip-code=${zipCode};coordinates=${geoCoordinates.join(
-      ','
-    )}${pickup ? `;pickupPoint=${pickup.pickupPoint.id}` : ''}"}}}`,
+    body: `{"public":{"facets":{"value":"${facetsValue}"}}}`,
     headers: {
       'Content-Type': 'application/json',
     },
   })
+}
 
 export const getPickups = (
   countryCode: string,

--- a/react/constants.ts
+++ b/react/constants.ts
@@ -1,2 +1,3 @@
 export const DELIVER_DRAWER_PIXEL_EVENT_ID = 'shipping-option-deliver-to'
 export const STORE_DRAWER_PIXEL_EVENT_ID = 'shipping-option-store'
+export const SHIPPING_INFO_COOKIE = 'shipping_info'

--- a/react/utils/cookie.ts
+++ b/react/utils/cookie.ts
@@ -15,7 +15,7 @@ export function setCookie(name: string, val: string) {
   const date = new Date()
   const value = val
 
-  date.setTime(date.getTime() + 7 * 24 * 60 * 60 * 1000)
+  date.setTime(date.getTime() + 30 * 60 * 1000)
 
   document.cookie = `${name}=${value}; expires=${date.toUTCString()}; path=/`
 }


### PR DESCRIPTION
#### What problem is this solving?

Currently we use the `__RUNTIME__.segmentToken` to get the last shipping information selected by the user. Unfortunately, this source is not reliable and might be outdated. For this reason, this PR adds the `shipping_info` cookie to be the primary source for the shipping information.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--vinotecamx.myvtex.com/)

