### PR TITLE
fix: hideStoreSelection just hides the button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The hideStoreSelection property removes the Pickup Drawer and it cannot be opened
+
 ## [0.5.1] - 2024-12-19
 
 ### Fixed

--- a/react/components/PickupDrawer.tsx
+++ b/react/components/PickupDrawer.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
 import { useIntl } from 'react-intl'
 import { usePixel } from 'vtex.pixel-manager'
+import { useCssHandles } from 'vtex.css-handles'
 
 import ShippingOptionDrawer from './ShippingOptionDrawer'
 import ShippingOptionButton from './ShippingOptionButton'
 import { STORE_DRAWER_PIXEL_EVENT_ID } from '../constants'
 import messages from '../messages'
 import PickupSelection from './PickupSelection'
+
+const CSS_HANDLES = ['drawerHiddenIcon'] as const
 
 interface Props {
   isLoading: boolean
@@ -20,6 +23,7 @@ interface Props {
   pickups: Pickup[]
   onSelectPickup: (pickup: Pickup) => void
   compact: boolean
+  hideStoreSelection: boolean
 }
 
 const PikcupDrawer = ({
@@ -34,9 +38,11 @@ const PikcupDrawer = ({
   selectedPickup,
   onSelectPickup,
   compact,
+  hideStoreSelection,
 }: Props) => {
   const intl = useIntl()
   const { push } = usePixel()
+  const handles = useCssHandles(CSS_HANDLES)
 
   const onOpen = () => {
     push({
@@ -56,14 +62,18 @@ const PikcupDrawer = ({
   return (
     <ShippingOptionDrawer
       icon={
-        <ShippingOptionButton
-          onClick={onOpen}
-          loading={isLoading}
-          value={storeLabel}
-          placeholder={intl.formatMessage(messages.storeButtonPlaceHolder)}
-          label={intl.formatMessage(messages.storeButtonLabel)}
-          compact={compact}
-        />
+        hideStoreSelection ? (
+          <div className={`${handles.drawerHiddenIcon}`} />
+        ) : (
+          <ShippingOptionButton
+            onClick={onOpen}
+            loading={isLoading}
+            value={storeLabel}
+            placeholder={intl.formatMessage(messages.storeButtonPlaceHolder)}
+            label={intl.formatMessage(messages.storeButtonLabel)}
+            compact={compact}
+          />
+        )
       }
       title={intl.formatMessage(drawerTitleMessage)}
       customPixelEventId={STORE_DRAWER_PIXEL_EVENT_ID}

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -65,21 +65,20 @@ function ShippingOptionZipCode({
         compact={compactMode}
         overlayType={overlayType}
       />
-      {!hideStoreSelection && (
-        <PikcupDrawer
-          isLoading={isLoading}
-          onChange={onChange}
-          onSubmit={() => onSubmit(false)}
-          addressLabel={addressLabel}
-          inputErrorMessage={inputErrorMessage}
-          selectedZipCode={selectedZipCode}
-          zipCode={zipCode}
-          pickups={pickups}
-          selectedPickup={selectedPickup}
-          onSelectPickup={onSelectPickup}
-          compact={compactMode}
-        />
-      )}
+      <PikcupDrawer
+        isLoading={isLoading}
+        onChange={onChange}
+        onSubmit={() => onSubmit(false)}
+        addressLabel={addressLabel}
+        inputErrorMessage={inputErrorMessage}
+        selectedZipCode={selectedZipCode}
+        zipCode={zipCode}
+        pickups={pickups}
+        selectedPickup={selectedPickup}
+        onSelectPickup={onSelectPickup}
+        compact={compactMode}
+        hideStoreSelection={hideStoreSelection}
+      />
     </>
   )
 }

--- a/react/styles.css
+++ b/react/styles.css
@@ -104,6 +104,10 @@
   width: 100%;
 }
 
+.openIconContainer:has(.drawerHiddenIcon) {
+  display: none;
+}
+
 @keyframes fadein {
   from {
     opacity: 0;


### PR DESCRIPTION
#### What problem is this solving?

The hideStoreSelection property hides the pickup drawer and when the pickup facet is clicked, the drawer does not work. This PR changes this behavior to just hide the button in the header and the drawer can be opened with the facet.

#### How to test it?
Add the hideStoreSelection property in the store-theme and click the button to select the store in the pickup facet.

[Workspace](https://dpdemo--iohinodeb2b.myvtex.com/todos-os-produtos)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/0a5bd4e9-1850-4e97-a594-d80870688a3c


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
