### PR TITLE
feat: remove ZipCodeValue from postal code input

### DIFF
--- a/react/components/DeliveryDrawer.tsx
+++ b/react/components/DeliveryDrawer.tsx
@@ -85,7 +85,6 @@ const DeliveryDrawer = ({
         isLoading={isLoading}
         onChange={onChange}
         onSubmit={onSubmit}
-        addressLabel={addressLabel}
         inputErrorMessage={inputErrorMessage}
         selectedZipCode={selectedZipCode}
         zipCode={zipCode}

--- a/react/components/DeliveryPopover.tsx
+++ b/react/components/DeliveryPopover.tsx
@@ -72,7 +72,6 @@ const DeliveryPopover = ({
               placeholder={intl.formatMessage(
                 messages.popoverPostalCodeInputPlaceHolder
               )}
-              newZipCodeTyped
             />
             <Button isLoading={isLoading} onClick={onSubmit}>
               {intl.formatMessage(messages.popoverSubmitButtonLabel)}

--- a/react/components/DeliverySelection.tsx
+++ b/react/components/DeliverySelection.tsx
@@ -10,7 +10,6 @@ interface Props {
   inputErrorMessage?: string
   zipCode?: string
   onChange: (zipCode?: string) => void
-  addressLabel?: string
   selectedZipCode?: string | null
   isLoading: boolean
 }
@@ -20,7 +19,6 @@ const DeliverySelection = ({
   inputErrorMessage,
   zipCode,
   onChange,
-  addressLabel,
   selectedZipCode,
   isLoading,
 }: Props) => {
@@ -35,9 +33,7 @@ const DeliverySelection = ({
         onSubmit={onSubmit}
         errorMessage={inputErrorMessage}
         onChange={onChange}
-        addressLabel={addressLabel}
         placeholder={intl.formatMessage(messages.postalCodeInputPlaceHolder)}
-        newZipCodeTyped={newZipCodeTyped}
       />
       <div className="fixed left-0 bottom-0 w-100 flex justify-center mb7">
         <SubmitButton

--- a/react/components/LocationModal/AddLocation.tsx
+++ b/react/components/LocationModal/AddLocation.tsx
@@ -44,7 +44,6 @@ const AddLocation = ({
           placeholder={intl.formatMessage(
             messages.popoverPostalCodeInputPlaceHolder
           )}
-          newZipCodeTyped
         />
         <div className="mt3">
           <PostalCodeHelpLink />

--- a/react/components/PickupDrawer.tsx
+++ b/react/components/PickupDrawer.tsx
@@ -14,7 +14,6 @@ const CSS_HANDLES = ['drawerHiddenIcon'] as const
 
 interface Props {
   isLoading: boolean
-  addressLabel?: string
   onSubmit: () => void
   inputErrorMessage?: string
   onChange: (zipCode?: string) => void
@@ -28,7 +27,6 @@ interface Props {
 }
 
 const PikcupDrawer = ({
-  addressLabel,
   isLoading,
   onChange,
   onSubmit,
@@ -96,7 +94,6 @@ const PikcupDrawer = ({
         isLoading={isLoading}
         onChange={onChange}
         onSubmit={onSubmit}
-        addressLabel={addressLabel}
         inputErrorMessage={inputErrorMessage}
         selectedZipCode={selectedZipCode}
         zipCode={zipCode}

--- a/react/components/PickupSelection.tsx
+++ b/react/components/PickupSelection.tsx
@@ -11,7 +11,6 @@ interface Props {
   inputErrorMessage?: string
   zipCode?: string
   onChange: (zipCode?: string) => void
-  addressLabel?: string | null
   selectedZipCode?: string | null
   isLoading: boolean
   pickups: Pickup[]
@@ -26,7 +25,6 @@ const PickupSelection = ({
   inputErrorMessage,
   zipCode,
   onChange,
-  addressLabel,
   selectedZipCode,
   isLoading,
   pickups,
@@ -47,9 +45,7 @@ const PickupSelection = ({
           onSubmit={onSubmit}
           errorMessage={inputErrorMessage}
           onChange={onChange}
-          addressLabel={addressLabel}
           placeholder={intl.formatMessage(messages.postalCodeInputPlaceHolder)}
-          newZipCodeTyped={newZipCodeTyped}
         />
       </div>
       <div className="m-100 flex flex-column justify-center">

--- a/react/components/PostalCodeInput.tsx
+++ b/react/components/PostalCodeInput.tsx
@@ -1,42 +1,21 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Input, IconClear } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 
 import '../styles.css'
-import PinIcon from './PinIcon'
 
 const CSS_HANDLES = [
   'postalCodeInputClearButton',
-  'zipCodeValue',
   'postalCodeInputContainer',
 ] as const
-
-interface ZipCodeValueProps {
-  zipCode: string
-  onClick: () => void
-}
-
-const ZipCodeValue = ({ zipCode, onClick }: ZipCodeValueProps) => {
-  const handles = useCssHandles(CSS_HANDLES)
-
-  return (
-    <button className={handles.zipCodeValue} onClick={onClick}>
-      <PinIcon />
-
-      <span className="ml3">{zipCode}</span>
-    </button>
-  )
-}
 
 interface Props {
   onSubmit: () => void
   onChange: (zipCode?: string) => void
-  addressLabel?: string | null
   zipCode?: string
   errorMessage?: string
   showClearButton?: boolean
   placeholder?: string
-  newZipCodeTyped?: boolean
 }
 
 const PostalCodeInput = ({
@@ -44,60 +23,39 @@ const PostalCodeInput = ({
   errorMessage,
   onSubmit,
   onChange,
-  addressLabel,
   showClearButton = true,
   placeholder,
-  newZipCodeTyped,
 }: Props) => {
-  const [isZipCodeSet, setIsZipCodeSet] = useState(!!zipCode)
-
-  useEffect(() => {
-    if (errorMessage) {
-      setIsZipCodeSet(false)
-    }
-  }, [errorMessage])
-
   const handles = useCssHandles(CSS_HANDLES)
 
   return (
     <div className={handles.postalCodeInputContainer}>
-      {isZipCodeSet ? (
-        <ZipCodeValue
-          zipCode={(newZipCodeTyped ? zipCode : addressLabel) ?? ''}
-          onClick={() => setIsZipCodeSet(false)}
-        />
-      ) : (
-        <Input
-          autFocus
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            onChange(e.target.value.replace(/[^0-9]/g, ''))
+      <Input
+        autFocus
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          onChange(e.target.value.replace(/[^0-9]/g, ''))
+        }
+        onKeyDown={(e: { key: string }) => {
+          if (e.key === 'Enter') {
+            onSubmit()
           }
-          onBlur={() => {
-            !!zipCode && setIsZipCodeSet(true)
-          }}
-          onKeyDown={(e: { key: string }) => {
-            if (e.key === 'Enter') {
-              onSubmit()
-              setIsZipCodeSet(true)
-            }
-          }}
-          value={zipCode}
-          errorMessage={errorMessage}
-          placeholder={placeholder}
-          suffix={
-            showClearButton ? (
-              <button
-                className={handles.postalCodeInputClearButton}
-                onClick={() => {
-                  onChange('')
-                }}
-              >
-                <IconClear />
-              </button>
-            ) : null
-          }
-        />
-      )}
+        }}
+        value={zipCode}
+        errorMessage={errorMessage}
+        placeholder={placeholder}
+        suffix={
+          showClearButton ? (
+            <button
+              className={handles.postalCodeInputClearButton}
+              onClick={() => {
+                onChange('')
+              }}
+            >
+              <IconClear />
+            </button>
+          ) : null
+        }
+      />
     </div>
   )
 }

--- a/react/components/ShippingSelectionModal/index.tsx
+++ b/react/components/ShippingSelectionModal/index.tsx
@@ -33,7 +33,6 @@ const ShippingSelectionModal = ({
     onSelectPickup,
     onSubmit,
     pickups,
-    addressLabel,
     inputErrorMessage,
     selectedPickup,
     selectedZipCode,
@@ -68,7 +67,6 @@ const ShippingSelectionModal = ({
           onSelectPickup={onSelectPickup}
           onSubmit={onSubmit}
           pickups={pickups}
-          addressLabel={addressLabel}
           inputErrorMessage={inputErrorMessage}
           selectedPickup={selectedPickup}
           selectedZipCode={selectedZipCode}

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -151,7 +151,6 @@ function ShippingOptionZipCode({
           onSelectPickup,
           onSubmit: () => onSubmit(false),
           pickups,
-          addressLabel,
           inputErrorMessage,
           selectedPickup,
           selectedZipCode,


### PR DESCRIPTION
#### What problem is this solving?

Remove ZipCodeValue component from postal code input.

#### How to test it?

1. Add a postal code;
2. Reopen the modal;
3. See that the added value is in the input.

[Workspace](https://inputcep--mundodocabeleireiro.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
before
<img width="294" alt="image" src="https://github.com/user-attachments/assets/47606524-5e40-46e0-aef0-10e626c8414a" />

after
<img width="294" alt="image" src="https://github.com/user-attachments/assets/7cc4d5b0-9354-45a6-8117-a95df40800d1" />

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
