### PR TITLE
remove variant validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove DP variant validation.
+
 ## [0.5.4] - 2025-01-29
 
 ### Fixed

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable no-restricted-globals */
-import React, { useEffect, useState } from 'react'
-import { useSSR, useRuntime } from 'vtex.render-runtime'
+import React from 'react'
 
 import useShippingOptions from './hooks/useShippingOptions'
 import DeliveryDrawer from './components/DeliveryDrawer'
 import PikcupDrawer from './components/PickupDrawer'
-import { getCookie } from './utils/cookie'
 
 interface Props {
   hideStoreSelection?: boolean
@@ -18,9 +16,6 @@ function ShippingOptionZipCode({
   compactMode = false,
   overlayType = 'popover-input',
 }: Props) {
-  const { production } = useRuntime()
-  const [shouldRender, setShouldRender] = useState<boolean>(!production)
-
   const {
     inputErrorMessage,
     zipCode,
@@ -33,24 +28,6 @@ function ShippingOptionZipCode({
     selectedPickup,
     onSelectPickup,
   } = useShippingOptions()
-
-  const isSSR = useSSR()
-
-  useEffect(() => {
-    if (!isSSR) {
-      return
-    }
-
-    const variant = getCookie('sp-variant')
-
-    if (production && variant && variant.indexOf('delivery_promises') > -1) {
-      setShouldRender(true)
-    }
-  }, [production, isSSR])
-
-  if (!shouldRender) {
-    return null
-  }
 
   return (
     <>


### PR DESCRIPTION
#### What problem is this solving?

We will not use osiris anymore so we can remove the `variant` validation that we do before rendering the component

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://hiago--mundodocabeleireiro.myvtex.com/cabelo)

