### PR TITLE
Add unavailable items modal

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -36,5 +36,9 @@
   "store/shipping-option-zipcode.pickupSelection.title": "Choose a store",
   "store/shipping-option-zipcode.pickupSelection.noStoresState.title": "No stores available",
   "store/shipping-option-zipcode.pickupSelection.noStoresState.description": "There are no stores available for the postal code {postalCode}",
-  "store/shipping-option-zipcode.pickupSelection.noStoresState.button.label": "Continue with delivery"
+  "store/shipping-option-zipcode.pickupSelection.noStoresState.button.label": "Continue with delivery",
+  "store/shipping-option-zipcode.unavailableItems.title": "Items unavailable",
+  "store/shipping-option-zipcode.unavailableItems.description": "These item can't be delivered to {addressLabel} and they are not available in any pickup point",
+  "store/shipping-option-zipcode.unavailableItems.removeItemsButton.label": "Remove items",
+  "store/shipping-option-zipcode.unavailableItems.retryButton.label": "Enter another location"
 }

--- a/react/client.ts
+++ b/react/client.ts
@@ -65,3 +65,36 @@ export const updateOrderForm = (
       'Content-Type': 'application/json',
     },
   }).then((res) => res.json())
+
+export const getCartProducts = async (orderFormId: string) => {
+  const orderForm = await fetch(
+    `/api/checkout/pub/orderForm/${orderFormId}`
+  ).then((res) => res.json())
+
+  return orderForm.items
+}
+
+export const removeCartProductsById = async (
+  orderFormId: string,
+  cartProductsIndex: number[]
+) => {
+  const requestBody = {
+    orderItems: cartProductsIndex.map((productIndex) => ({
+      quantity: 0,
+      index: productIndex,
+    })),
+  }
+
+  const orderForm = await fetch(
+    `/api/checkout/pub/orderForm/${orderFormId}/items/update`,
+    {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  ).then((res) => res.json())
+
+  return orderForm.items
+}

--- a/react/components/Modal.tsx
+++ b/react/components/Modal.tsx
@@ -61,6 +61,7 @@ const Modal = ({
   if (isMobile) {
     customStyles.content.width = '100%'
   } else {
+    customStyles.content.width = '522px'
     customStyles.content.minWidth = '522px'
   }
 

--- a/react/components/UnavailableItemsModal/ProductItem.tsx
+++ b/react/components/UnavailableItemsModal/ProductItem.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+interface Props {
+  imageUrl: string
+  productName: string
+}
+
+const ProductItem = ({ imageUrl, productName }: Props) => {
+  return (
+    <div className="flex flex-row pa5 bg-base t-body c-on-base br3 b--muted-4 ba mb5">
+      <img
+        className="br2"
+        style={{ width: '64px', height: '64px' }}
+        src={imageUrl}
+        alt={productName}
+      />
+      <p className="ml6">{productName}</p>
+    </div>
+  )
+}
+
+export default ProductItem

--- a/react/components/UnavailableItemsModal/index.tsx
+++ b/react/components/UnavailableItemsModal/index.tsx
@@ -5,8 +5,6 @@ import { useIntl } from 'react-intl'
 
 import Modal from '../Modal'
 import ProductItem from './ProductItem'
-import { removeCartProductsById } from '../../client'
-import { getOrderFormId } from '../../utils/cookie'
 import messages from '../../messages'
 
 export type CartProduct = { id: string; name: string; imageUrl: string }
@@ -20,6 +18,7 @@ interface Props {
   isOpen: boolean
   onClose: () => void
   onTryAgain: () => void
+  onRemoveItems: () => void
   addressLabel: string
   unavailableCartItems: CartItem[]
 }
@@ -28,6 +27,7 @@ const UnavailableItemsModal = ({
   isOpen,
   onClose,
   onTryAgain,
+  onRemoveItems,
   addressLabel,
   unavailableCartItems,
 }: Props) => {
@@ -35,17 +35,11 @@ const UnavailableItemsModal = ({
 
   const [isLoading, setIsLoading] = useState(false)
 
-  const handleRemoveItemsClick = () => {
-    const orderFormId = getOrderFormId()
-
+  const handleRemoveItemsClick = async () => {
     setIsLoading(true)
-    removeCartProductsById(
-      orderFormId,
-      unavailableCartItems.map((item) => item.cartItemIndex)
-    ).then(() => setIsLoading(false))
+    await onRemoveItems()
 
     onClose()
-    location.reload()
   }
 
   return (

--- a/react/components/UnavailableItemsModal/index.tsx
+++ b/react/components/UnavailableItemsModal/index.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable no-restricted-globals */
+import React, { useState } from 'react'
+import { Button } from 'vtex.styleguide'
+import { useIntl } from 'react-intl'
+
+import Modal from '../Modal'
+import ProductItem from './ProductItem'
+import { removeCartProductsById } from '../../client'
+import { getOrderFormId } from '../../utils/cookie'
+import messages from '../../messages'
+
+export type CartProduct = { id: string; name: string; imageUrl: string }
+
+export type CartItem = {
+  cartItemIndex: number
+  product: CartProduct
+}
+
+interface Props {
+  isOpen: boolean
+  onClose: () => void
+  onTryAgain: () => void
+  addressLabel: string
+  unavailableCartItems: CartItem[]
+}
+
+const UnavailableItemsModal = ({
+  isOpen,
+  onClose,
+  onTryAgain,
+  addressLabel,
+  unavailableCartItems,
+}: Props) => {
+  const intl = useIntl()
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleRemoveItemsClick = () => {
+    const orderFormId = getOrderFormId()
+
+    setIsLoading(true)
+    removeCartProductsById(
+      orderFormId,
+      unavailableCartItems.map((item) => item.cartItemIndex)
+    ).then(() => setIsLoading(false))
+
+    onClose()
+    location.reload()
+  }
+
+  return (
+    <Modal
+      showArrowBack={false}
+      isTopCloseButton={false}
+      title={intl.formatMessage(messages.unavailableItemsModalTitle)}
+      isOpen={isOpen}
+      onClose={onClose}
+      nonDismissible
+    >
+      <div className="flex-auto flex flex-column justify-between mt0">
+        <p className="mid-gray ma0">
+          {intl.formatMessage(messages.unavailableItemsModalDescription, {
+            addressLabel: ` ${addressLabel}`,
+          })}
+        </p>
+        <div className="mv7 overflow-auto">
+          {unavailableCartItems.map(({ product }) => (
+            <ProductItem
+              key={product.id}
+              imageUrl={product.imageUrl}
+              productName={product.name}
+            />
+          ))}
+        </div>
+        <div style={{ gap: '.75rem' }} className="flex flex-column">
+          <Button
+            className="mb3"
+            isLoading={isLoading}
+            onClick={handleRemoveItemsClick}
+          >
+            {intl.formatMessage(messages.unavailableItemsModalRemoveButton)}
+          </Button>
+          <Button
+            isLoading={isLoading}
+            variation="secondary"
+            onClick={onTryAgain}
+          >
+            {intl.formatMessage(messages.unavailableItemsModalRetryButton)}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default UnavailableItemsModal

--- a/react/hooks/useShippingOptions.ts
+++ b/react/hooks/useShippingOptions.ts
@@ -10,6 +10,7 @@ import {
   getAddress,
   getCartProducts,
   getPickups,
+  removeCartProductsById,
   updateOrderForm,
   updateSession,
 } from '../client'
@@ -211,6 +212,17 @@ const useShippingOptions = () => {
     return true
   }
 
+  const removeUnavailableItems = async () => {
+    const orderFormId = getOrderFormId()
+
+    await removeCartProductsById(
+      orderFormId,
+      unavailableCartItems.map((item) => item.cartItemIndex)
+    )
+
+    onSubmit()
+  }
+
   const onChange = (zipCode?: string) => {
     setInputZipCode(zipCode)
   }
@@ -256,6 +268,7 @@ const useShippingOptions = () => {
     shippingOption,
     countryCode,
     unavailableCartItems,
+    removeUnavailableItems,
   }
 }
 

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -61,6 +61,7 @@ function ShippingOptionZipCode({
     shippingOption,
     countryCode,
     unavailableCartItems,
+    removeUnavailableItems,
   } = useShippingOptions()
 
   usePixelEventCallback({
@@ -199,6 +200,7 @@ function ShippingOptionZipCode({
         isOpen={openModal === 'unavailable-items'}
         onClose={() => setOpenModal(null)}
         onTryAgain={() => setOpenModal('location')}
+        onRemoveItems={removeUnavailableItems}
         unavailableCartItems={unavailableCartItems}
       />
     </>

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -15,6 +15,14 @@ import { LocationModal } from './components/LocationModal'
 import ShippingOptionButton from './components/ShippingOptionButton'
 import messages from './messages'
 import PickupModal from './components/PickupModal'
+import UnavailableItemsModal from './components/UnavailableItemsModal'
+
+type OpenModal =
+  | 'location'
+  | 'shipping-selection'
+  | 'unavailable-items'
+  | 'pickup'
+  | null
 
 interface Props {
   hideStoreSelection?: boolean
@@ -28,12 +36,11 @@ function ShippingOptionZipCode({
   compactMode = false,
   callToAction = 'popover-input',
   dismissible = false,
-  shippingSelection,
+  shippingSelection = 'only-pickup',
 }: Props) {
   const intl = useIntl()
-  const [isShippingModalOpen, setIsShippingModalOpen] = useState(false)
-  const [isLocationModalOpen, setIsLocationModalOpen] = useState<boolean>(false)
-  const [isPickupModalOpen, setisPickupModalOpen] = useState<boolean>(false)
+  const [openModal, setOpenModal] = useState<OpenModal>(null)
+
   const [
     wasLocationModalOpenedByEvent,
     setWasLocationModalOpenedByEvent,
@@ -53,16 +60,17 @@ function ShippingOptionZipCode({
     geoCoordinates,
     shippingOption,
     countryCode,
+    unavailableCartItems,
   } = useShippingOptions()
 
   usePixelEventCallback({
     eventId: SHIPPING_MODAL_PIXEL_EVENT_ID,
     handler: () => {
       if (selectedZipCode) {
-        setIsShippingModalOpen(true)
+        setOpenModal('shipping-selection')
       } else {
         setWasLocationModalOpenedByEvent(true)
-        setIsLocationModalOpen(true)
+        setOpenModal('location')
       }
     },
   })
@@ -70,20 +78,26 @@ function ShippingOptionZipCode({
   usePixelEventCallback({
     eventId: STORE_DRAWER_PIXEL_EVENT_ID,
     handler: () => {
-      setisPickupModalOpen(true)
+      setOpenModal('pickup')
     },
   })
 
   usePixelEventCallback({
     eventId: DELIVER_DRAWER_PIXEL_EVENT_ID,
-    handler: () => setIsLocationModalOpen(true),
+    handler: () => setOpenModal('location'),
   })
 
   useEffect(() => {
     if (selectedZipCode === null && callToAction === 'modal') {
-      setIsLocationModalOpen(true)
+      setOpenModal('location')
     }
   }, [callToAction, selectedZipCode])
+
+  useEffect(() => {
+    if (unavailableCartItems.length > 0) {
+      setOpenModal('unavailable-items')
+    }
+  }, [unavailableCartItems])
 
   const showDeliveryModalButton = shippingSelection === 'delivery-and-pickup'
   const showPickupButton = shippingSelection === 'only-pickup'
@@ -93,7 +107,7 @@ function ShippingOptionZipCode({
       <ShippingOptionButton
         onClick={() => {
           setWasLocationModalOpenedByEvent(false)
-          setIsLocationModalOpen(true)
+          setOpenModal('location')
         }}
         loading={isLoading}
         value={addressLabel}
@@ -106,19 +120,17 @@ function ShippingOptionZipCode({
         inputErrorMessage={inputErrorMessage}
         callToAction={callToAction}
       />
-
       {selectedZipCode && showDeliveryModalButton && (
         <DeliveryModalButton
-          onClick={() => setIsShippingModalOpen(true)}
+          onClick={() => setOpenModal('shipping-selection')}
           selectedShipping={shippingOption}
           selectedPickup={selectedPickup}
           loading={isLoading}
         />
       )}
-
       {selectedZipCode && showPickupButton && (
         <ShippingOptionButton
-          onClick={() => setisPickupModalOpen(true)}
+          onClick={() => setOpenModal('pickup')}
           loading={isLoading}
           value={selectedPickup?.pickupPoint.friendlyName}
           placeholder={intl.formatMessage(messages.storeButtonPlaceHolder)}
@@ -126,10 +138,9 @@ function ShippingOptionZipCode({
           compact={compactMode}
         />
       )}
-
       <LocationModal
-        isOpen={isLocationModalOpen}
-        onClose={() => setIsLocationModalOpen(false)}
+        isOpen={openModal === 'location'}
+        onClose={() => setOpenModal(null)}
         onChange={onChange}
         onSubmit={async () => {
           const shouldReload = !wasLocationModalOpenedByEvent
@@ -137,8 +148,7 @@ function ShippingOptionZipCode({
           const success = await onSubmit(shouldReload)
 
           if (!shouldReload && success) {
-            setIsLocationModalOpen(false)
-            setIsShippingModalOpen(true)
+            setOpenModal('shipping-selection')
           }
         }}
         isLoading={isLoading}
@@ -148,10 +158,9 @@ function ShippingOptionZipCode({
           !dismissible && !selectedZipCode && wasLocationModalOpenedByEvent
         }
       />
-
       <ShippingSelectionModal
-        isOpen={isShippingModalOpen}
-        onClose={() => setIsShippingModalOpen(false)}
+        isOpen={openModal === 'shipping-selection'}
+        onClose={() => setOpenModal(null)}
         geoCoordinates={geoCoordinates}
         selectedShipping={shippingOption}
         countryCode={countryCode}
@@ -170,10 +179,9 @@ function ShippingOptionZipCode({
           !dismissible && !shippingOption && wasLocationModalOpenedByEvent
         }
       />
-
       <PickupModal
-        isOpen={isPickupModalOpen}
-        onClose={() => setisPickupModalOpen(false)}
+        isOpen={openModal === 'pickup'}
+        onClose={() => setOpenModal(null)}
         pickupProps={{
           onChange,
           onSelectPickup,
@@ -185,6 +193,13 @@ function ShippingOptionZipCode({
           zipCode,
           isLoading,
         }}
+      />
+      <UnavailableItemsModal
+        addressLabel={addressLabel ?? ''}
+        isOpen={openModal === 'unavailable-items'}
+        onClose={() => setOpenModal(null)}
+        onTryAgain={() => setOpenModal('location')}
+        unavailableCartItems={unavailableCartItems}
       />
     </>
   )

--- a/react/messages.ts
+++ b/react/messages.ts
@@ -120,6 +120,23 @@ const messages = defineMessages({
     id: 'store/shipping-option-zipcode.pickupSelection.title',
     defaultMessaage: '',
   },
+  unavailableItemsModalRemoveButton: {
+    id:
+      'store/shipping-option-zipcode.unavailableItems.removeItemsButton.label',
+    defaultMessaage: '',
+  },
+  unavailableItemsModalRetryButton: {
+    id: 'store/shipping-option-zipcode.unavailableItems.retryButton.label',
+    defaultMessaage: '',
+  },
+  unavailableItemsModalTitle: {
+    id: 'store/shipping-option-zipcode.unavailableItems.title',
+    defaultMessaage: '',
+  },
+  unavailableItemsModalDescription: {
+    id: 'store/shipping-option-zipcode.unavailableItems.description',
+    defaultMessaage: '',
+  },
 })
 
 export default messages


### PR DESCRIPTION
#### What problem is this solving?

This PR adds the modal that shows all products in the cart that are unavailable in the selected zip code.

[Task TIS-187](https://vtex-dev.atlassian.net/browse/TIS-187)

#### How to test it?

1. Add products to the mini cart;
2. Open the location modal by clicking the header button;
3. Add a zip code.

[Workspace](https://tis187--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/1bb2aceb-a089-49c6-950e-1054a23cb461

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExdjUzMGxhZGZwbDlva3RkbGkzb3gwMTQzZncxbzFnN2p1aHE1MXhrOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kyLYXonQYYfwYDIeZl/giphy.gif)
