### PR TITLE
fix: remove justify-between to the PickupSelection component

### DIFF
--- a/react/components/PickupSelection/index.tsx
+++ b/react/components/PickupSelection/index.tsx
@@ -37,7 +37,7 @@ const PickupSelection = ({
   useEffect(() => setZipcode(selectedZipcode ?? ''), [selectedZipcode])
 
   return (
-    <div className="flex flex-column justify-between mt5 vh-100">
+    <div className="flex flex-column mt5 vh-100">
       <div className="mb7">
         <PostalCodeInput
           onChange={(value: string) => setZipcode(value)}


### PR DESCRIPTION
#### What problem is this solving?
The store selection modal has a justify-between that adds unnecessary space.

#### How to test it?

Open the store selection modal to see the space between the list and the input.

[Workspace](https://www.vinoteca.com/vinos-exclusivos)

#### Screenshots or example usage:

before
<img width="689" alt="image" src="https://github.com/user-attachments/assets/cdc3e12f-49e2-4c35-821d-6019289f5740" />

after
<img width="689" alt="image" src="https://github.com/user-attachments/assets/69a4a7aa-27f4-4528-8be9-0287433061c9" />

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
