### PR TITLE
feat: select PLP facet when global method is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Always add the shippingOption to the session.
+
 ## [1.7.1] - 2025-10-06
 
 ### Changed

--- a/react/components/PickupModal.tsx
+++ b/react/components/PickupModal.tsx
@@ -39,7 +39,6 @@ const PickupModal = ({ isOpen, onClose, pickupProps }: Props) => {
         inputErrorMessage={inputErrorMessage}
         selectedPickup={selectedPickup}
         selectedZipcode={selectedZipcode}
-        shouldPersistFacet={false}
         isLoading={isLoading}
       />
     </Modal>

--- a/react/context/useShippingOption.ts
+++ b/react/context/useShippingOption.ts
@@ -264,7 +264,13 @@ export const useShippingOption = () => {
       setGeoCoordinates(coordinates)
       setZipCode(selectedZipcode)
 
-      await updateSession(countryCode, selectedZipcode, coordinates)
+      await updateSession(
+        countryCode,
+        selectedZipcode,
+        coordinates,
+        selectedPickup,
+        'delivery'
+      )
 
       await fetchPickups(
         countryCode,


### PR DESCRIPTION
#### What problem is this solving?

This PR makes possible to select PLP facet when the global method(delivery or pickup) is selected.

#### How to test it?

1. Add a postal code and/or select a pickup point
2. See selected the 'delivery' facet or pickup facet

[Workspace](https://testenavigation--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo/)

#### Screenshots or example usage:

https://github.com/user-attachments/assets/5ad8dcca-0afc-47a5-ae85-80fbd1d93082


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
