### PR TITLE
fix: send zipcode as a string in update orderForm request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Send zipCode as a string in update orderForm request
+
 ## [1.6.2] - 2025-09-23
 
 ### Removed

--- a/react/client.ts
+++ b/react/client.ts
@@ -60,7 +60,7 @@ export const updateOrderForm = (
 ) =>
   fetch(`/api/checkout/pub/orderForm/${orderFormId}/attachments/shippingData`, {
     method: 'POST',
-    body: `{"selectedAddresses": [{ "postalCode": ${zipCode}, "country": "${country}" }]}`,
+    body: `{"selectedAddresses": [{ "postalCode": "${zipCode}", "country": "${country}" }]}`,
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
#### What problem is this solving?
Our app calls the OrderForm API with the wrong format, the CEP is being passed as a Number and not a String.
This causes an error message and does not update the shipping method for checkout

#### How to test it?

Just change the cep and see the request work: `/api/checkout/pub/orderForm/<<id>>/attachments/shippingData
`
[Workspace](https://tis109--mundodocabeleireiro.myvtex.com/cabelo/marcas-de-salao/shampoo)

#### Screenshots or example usage:
<img width="738" height="737" alt="image" src="https://github.com/user-attachments/assets/5ec42527-6eaa-4e08-8ddd-153b69452881" />
<img width="738" height="207" alt="image" src="https://github.com/user-attachments/assets/4cee98b3-63b5-4927-a7fa-468d309d2bc5" />

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
